### PR TITLE
Removed unsupported pygments highlighter with rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ sass:
   style: compressed
 permalink: /:categories/:title/
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 gems:
   - jekyll-sitemap
 


### PR DESCRIPTION
GitHub Pages does not support pygments, so replace it with rouge.